### PR TITLE
Add options to change layout of some widgets

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Roland Planitz
-most Code was done by 2024 Daniel Barrios
+Copyright (c) 2024 Daniel Barrios
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2024 Daniel Barrios
+Copyright (c) 2025 Roland Planitz
+most Code was done by 2024 Daniel Barrios
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ EdgeTX widgets enhance the functionality of your transmitter, allowing you to cu
 1. **EdgeTX Firmware**: Ensure your transmitter is running EdgeTX firmware.
    - [Download EdgeTX](https://www.edgetx.org/)
    - **Compatibility**: These widgets have only been tested with EdgeTX 2.10.5.
-   - SimModel and SimStick work on EdgeTX 2.11.1
+   - ModelWidget, ClockWidget, SimModel and SimStick work on EdgeTX 2.11.1
 2. **SD Card Setup**:
    - Verify that your SD card has the correct file structure for EdgeTX.
    - Use the [EdgeTX Companion](https://www.edgetx.org/tools) to update your SD card contents, if necessary.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ EdgeTX widgets enhance the functionality of your transmitter, allowing you to cu
 1. **EdgeTX Firmware**: Ensure your transmitter is running EdgeTX firmware.
    - [Download EdgeTX](https://www.edgetx.org/)
    - **Compatibility**: These widgets have only been tested with EdgeTX 2.10.5.
+   - SimModel and SimStick work on EdgeTX 2.11.1
 2. **SD Card Setup**:
    - Verify that your SD card has the correct file structure for EdgeTX.
    - Use the [EdgeTX Companion](https://www.edgetx.org/tools) to update your SD card contents, if necessary.

--- a/README.md
+++ b/README.md
@@ -118,5 +118,5 @@ Place the widgets in the order specified on the next image. Location details:
 2. Delete the folders corresponding to the widget you wish to remove.
 
 ## Additional Resources
-- [EdgeTX Documentation](https://www.edgetx.org/documentation)
+- [EdgeTX Documentation](https://manual.edgetx.org)
 - [EdgeTX GitHub](https://github.com/EdgeTX)

--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ EdgeTX widgets enhance the functionality of your transmitter, allowing you to cu
 
 1. **EdgeTX Firmware**: Ensure your transmitter is running EdgeTX firmware.
    - [Download EdgeTX](https://www.edgetx.org/)
-   - **Compatibility**: These widgets have only been tested with EdgeTX 2.10.5.
-   - ModelWidget, ClockWidget, SimModel and SimStick work on EdgeTX 2.11.1
+   - **Compatibility**: These widgets have only been tested with EdgeTX 2.10.5 (and 2.11.1).
 2. **SD Card Setup**:
    - Verify that your SD card has the correct file structure for EdgeTX.
    - Use the [EdgeTX Companion](https://www.edgetx.org/tools) to update your SD card contents, if necessary.

--- a/widgets/BattWidget/main.lua
+++ b/widgets/BattWidget/main.lua
@@ -4,105 +4,109 @@ local midLineHeight = 33
 local lineHeight = 18
 
 local function getVoltagePerCell(rxBt)
-    local maxCellVoltage = 4.35
-    local minCellVoltage = 3.0
+  local maxCellVoltage = 4.35
+  local minCellVoltage = 3.0
 
-    if rxBt > 5 then
-        local estimatedCellCount = math.floor(rxBt / maxCellVoltage) + 1
-        local averageVoltagePerCell = rxBt / estimatedCellCount
+  if rxBt > 5 then
+    local estimatedCellCount = math.floor(rxBt / maxCellVoltage) + 1
+    local averageVoltagePerCell = rxBt / estimatedCellCount
 
-        if averageVoltagePerCell >= minCellVoltage and averageVoltagePerCell <= maxCellVoltage then
-            return averageVoltagePerCell, estimatedCellCount
-        end
+    if averageVoltagePerCell >= minCellVoltage and averageVoltagePerCell <= maxCellVoltage then
+      return averageVoltagePerCell, estimatedCellCount
     end
-    return rxBt, 1
+  end
+  return rxBt, 1
 end
 
 local function drawBatteryTelemetry(widget)
-    local xRight = widget.zone.x + widget.zone.w - 10
-    local yStart = widget.zone.y + 15
+  local xRight = widget.zone.x + widget.zone.w - 10
+  local yStart = widget.zone.y + 15
 
-    local totalBatt = tonumber(getValue("RxBt")) or 0
-    local voltagePerCell, cellCount = getVoltagePerCell(totalBatt)
-    local rxBt = tonumber(voltagePerCell) or 0
+  local totalBatt = tonumber(getValue("RxBt")) or 0
+  local voltagePerCell, cellCount = getVoltagePerCell(totalBatt)
+  local rxBt = tonumber(voltagePerCell) or 0
 
-    local curr = tonumber(getValue("Curr")) or 0
-    local capa = tonumber(getValue("Capa")) or 0
+  local curr = tonumber(getValue("Curr")) or 0
+  local capa = tonumber(getValue("Capa")) or 0
 
-    -- Select icon based on voltage per cell
-    local icon
-    if rxBt < 3.2 then
-        icon = widget.icons.dead
-    elseif rxBt < 3.6 then
-        icon = widget.icons.low
-    elseif rxBt < 3.8 then
-        icon = widget.icons.yellow
-    elseif rxBt < 4.0 then
-        icon = widget.icons.ok
-    else
-        icon = widget.icons.full
-    end
+  -- Select icon based on voltage per cell
+  local icon
+  if rxBt < 3.2 then
+    icon = widget.icons.dead
+  elseif rxBt < 3.6 then
+    icon = widget.icons.low
+  elseif rxBt < 3.8 then
+    icon = widget.icons.yellow
+  elseif rxBt < 4.0 then
+    icon = widget.icons.ok
+  else
+    icon = widget.icons.full
+  end
 
-    if icon then
-        lcd.drawBitmap(icon, xRight - 22, yStart - 2)
-    end
+  if icon then
+    lcd.drawBitmap(icon, xRight - 22, yStart - 2)
+  end
 
-    -- Draw voltage text
-    if cellCount > 1 then
-        lcd.drawText(xRight - 25, yStart + 2, string.format("%.2fV", rxBt) .. "-" .. cellCount .. "S", textStyle + MIDSIZE)
-    else
-        lcd.drawText(xRight - 29, yStart + 2, string.format("%.1fV", rxBt), textStyle + MIDSIZE)
-    end
+  -- Draw voltage text
+  if cellCount > 1 then
+    lcd.drawText(xRight - 25, yStart + 2, string.format("%.2fV", rxBt) .. "-" .. cellCount .. "S", textStyle + MIDSIZE)
+  else
+    lcd.drawText(xRight - 29, yStart + 2, string.format("%.1fV", rxBt), textStyle + MIDSIZE)
+  end
 
-    -- Draw current and capacity
-    lcd.drawText(xRight, yStart + midLineHeight, string.format("Curr: %.2fA", curr), textStyle)
-    lcd.drawText(xRight, yStart + midLineHeight + lineHeight, string.format("Cap: %dmAh", capa), textStyle)
+  -- Draw current and capacity
+  lcd.drawText(xRight, yStart + midLineHeight, string.format("Curr: %.2fA", curr), textStyle)
+  lcd.drawText(xRight, yStart + midLineHeight + lineHeight, string.format("Cap: %dmAh", capa), textStyle)
 end
 
 local function create(zone, options)
-    -- Preload icons once during widget creation
-    local iconPath = "/WIDGETS/BattWidget/BMP/battery-%s.png"
-    local icons = {
-        dead = Bitmap.open(string.format(iconPath, "dead")),
-        low = Bitmap.open(string.format(iconPath, "low")),
-        yellow = Bitmap.open(string.format(iconPath, "yellow")),
-        ok = Bitmap.open(string.format(iconPath, "ok")),
-        full = Bitmap.open(string.format(iconPath, "full")),
-    }
+  -- Preload icons once during widget creation
+  local iconPath = "/WIDGETS/BattWidget/BMP/battery-%s.png"
+  local icons = {
+    dead = Bitmap.open(string.format(iconPath, "dead")),
+    low = Bitmap.open(string.format(iconPath, "low")),
+    yellow = Bitmap.open(string.format(iconPath, "yellow")),
+    ok = Bitmap.open(string.format(iconPath, "ok")),
+    full = Bitmap.open(string.format(iconPath, "full")),
+  }
 
-    return {
-        zone = zone,
-        cfg = options,
-        icons = icons,
-    }
+  return {
+    zone = zone,
+    cfg = options,
+    icons = icons,
+  }
 end
 
 local function update(widget, options)
-    widget.cfg = options
+  widget.cfg = options
 end
 
 local function refresh(widget, event, touchState)
-    local tpwr = tonumber(getValue("TPWR")) or 0
-    if tpwr > 0 then
-        drawBatteryTelemetry(widget)
-    end
+  local tpwr = tonumber(getValue("TPWR")) or 0
+  if tpwr > 0 then
+    drawBatteryTelemetry(widget)
+  else
+    local xRight = widget.zone.x + widget.zone.w - 10
+    local yStart = widget.zone.y + 15 + midLineHeight
+    lcd.drawText(xRight, yStart, string.format("no battery telemetry"), textStyle)
+  end
 end
 
 local function destroy(widget)
-    -- Clean up bitmaps when widget is destroyed
-    for key, bmp in pairs(widget.icons or {}) do
-        if bmp and bmp.delete then
-            bmp:delete()
-        end
+  -- Clean up bitmaps when widget is destroyed
+  for key, bmp in pairs(widget.icons or {}) do
+    if bmp and bmp.delete then
+      bmp:delete()
     end
-    widget.icons = nil
+  end
+  widget.icons = nil
 end
 
 return {
-    name = "BattWidget",
-    options = {},
-    create = create,
-    update = update,
-    refresh = refresh,
-    destroy = destroy,  -- Important to release memory
+  name = "BattWidget",
+  options = {},
+  create = create,
+  update = update,
+  refresh = refresh,
+  destroy = destroy,  -- Important to release memory
 }

--- a/widgets/BattWidget/main.lua
+++ b/widgets/BattWidget/main.lua
@@ -88,7 +88,7 @@ local function refresh(widget, event, touchState)
   else
     local xRight = widget.zone.x + widget.zone.w - 10
     local yStart = widget.zone.y + 15 + midLineHeight
-    lcd.drawText(xRight, yStart, string.format("no battery telemetry"), textStyle)
+    lcd.drawText(xRight, yStart, string.format("No battery telemetry"), textStyle)
   end
 end
 

--- a/widgets/ClockWidget/README.md
+++ b/widgets/ClockWidget/README.md
@@ -1,0 +1,12 @@
+# ClockWidget
+... now with options to change the visual representation.
+The defaults are set to keep everything as it was before.
+
+### Options
+
+**iso8601**
+Show the Date and Time in a single line in `%Y-%m-%d %H:%M` format.
+
+**timers**
+Show the three timers below Date/Time.
+Only shows timers with a mode other than 'off'.

--- a/widgets/ClockWidget/main.lua
+++ b/widgets/ClockWidget/main.lua
@@ -1,103 +1,165 @@
--- ClockWidget: Displays current date and time with telemetry-based connection icon
 
 -- Constants
 local textStyle = RIGHT + WHITE + SHADOWED
 local lineHeight = 18
 local months = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", 
-                "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"}
+"Jul", "Aug", "Sep", "Oct", "Nov", "Dec"}
 local iconPathFmt = "/WIDGETS/ClockWidget/BMP/connection-%s.png"
+
 
 -- Function to format time string
 local function getFormattedTime(datetime, is24Hour)
-    local hour = datetime.hour
-    local amPm = ""
+  local hour = datetime.hour
+  local amPm = ""
 
-    if not is24Hour then
-        if hour == 0 then
-            hour = 12
-            amPm = " AM"
-        elseif hour == 12 then
-            amPm = " PM"
-        elseif hour > 12 then
-            hour = hour - 12
-            amPm = " PM"
-        else
-            amPm = " AM"
-        end
+  if not is24Hour then
+    if hour == 0 then
+      hour = 12
+      amPm = " AM"
+    elseif hour == 12 then
+      amPm = " PM"
+    elseif hour > 12 then
+      hour = hour - 12
+      amPm = " PM"
+    else
+      amPm = " AM"
     end
+  end
 
-    return string.format("%02d:%02d%s", hour, datetime.min, is24Hour and "" or amPm)
+  return string.format("%02d:%02d%s", hour, datetime.min, is24Hour and "" or amPm)
 end
 
 -- Widget creation: preload bitmaps
 local function create(zone, options)
-    local icons = {
-        red = Bitmap.open(string.format(iconPathFmt, "red")),
-        yellow = Bitmap.open(string.format(iconPathFmt, "yellow")),
-        green = Bitmap.open(string.format(iconPathFmt, "green")),
-        black = Bitmap.open(string.format(iconPathFmt, "black")),
-    }
+  local icons = {
+    red = Bitmap.open(string.format(iconPathFmt, "red")),
+    yellow = Bitmap.open(string.format(iconPathFmt, "yellow")),
+    green = Bitmap.open(string.format(iconPathFmt, "green")),
+    black = Bitmap.open(string.format(iconPathFmt, "black")),
+  }
 
-    return {
-        zone = zone,
-        options = options,
-        icons = icons,
-    }
+  return {
+    zone = zone,
+    cfg = options,
+    icons = icons,
+  }
 end
 
 -- Widget config update
 local function update(widget, options)
-    widget.options = options
+  widget.cfg = options
 end
 
 -- Main drawing function
 local function refresh(widget, event, touchState)
-    local datetime = getDateTime()
-    if not datetime then
-        lcd.drawText(widget.zone.x + 10, widget.zone.y + 10, "No Date/Time", MIDSIZE + RED)
-        return
-    end
+  local datetime = getDateTime()
+  if not datetime then
+    lcd.drawText(widget.zone.x + 10, widget.zone.y + 10, "No Date/Time", MIDSIZE + RED)
+    return
+  end
 
-    local tpwr = tonumber(getValue("TPWR")) or 0
-    local iconState
+  local tpwr = tonumber(getValue("TPWR")) or 0
+  local iconState
 
-    if tpwr > 0 then
-        local rqly = tonumber(getValue("RQly")) or 0
-        if rqly < 60 then
-            iconState = "red"
-        elseif rqly < 80 then
-            iconState = "yellow"
-        else
-            iconState = "green"
-        end
+  if tpwr > 0 then
+    local rqly = tonumber(getValue("RQly")) or 0
+    if rqly < 60 then
+      iconState = "red"
+    elseif rqly < 80 then
+      iconState = "yellow"
     else
-        iconState = "black"
+      iconState = "green"
     end
+  else
+    iconState = "black"
+  end
 
-    local is24Hour = widget.options.Format24H == 1
-    local timeStr = getFormattedTime(datetime, is24Hour)
-    local dateStr = string.format("%02d %s", datetime.day, months[datetime.mon] or "???")
+  local is24Hour = widget.cfg.Format24H == 1
+  local timeStr = getFormattedTime(datetime, is24Hour)
+  local dateStr = string.format("%02d %s", datetime.day, months[datetime.mon] or "???")
+  local isoStr = string.format("%04d-%02d-%02d %02d:%02d", datetime.year, datetime.mon, datetime.day, datetime.hour, datetime.min)
 
-    local xRight = widget.zone.x + widget.zone.w - 10
-    local yStart = widget.zone.y + 5
-    local iconRight = xRight - (is24Hour and 85 or 110)
+  local xRight = widget.zone.x + widget.zone.w - 10
+  local yStart = widget.zone.y + 5
+  local iconRight = xRight - (is24Hour and 85 or 110)
+  if widget.cfg.iso8601 == 1 then iconRight = xRight - 160 end
 
-    local icon = widget.icons[iconState]
-    if icon then
-        lcd.drawBitmap(icon, iconRight, yStart + 2)
-    end
+  local icon = widget.icons[iconState]
+  if icon then
+    lcd.drawBitmap(icon, iconRight, yStart + 2)
+  end
 
+  if widget.cfg.iso8601 == 0 then
     lcd.drawText(xRight, yStart, timeStr, textStyle)
     lcd.drawText(xRight, yStart + lineHeight, dateStr, textStyle)
+  else
+    lcd.drawText(xRight, yStart, isoStr, textStyle)
+  end
+
+  if widget.cfg.timers == 1 then
+    -- define height - adjust based on one line ISO or two line date/time
+    local timerY = yStart + lineHeight
+    if widget.cfg.iso8601 == 0 then timerY = timerY + lineHeight end
+
+    -- get timers
+    local t0 = model.getTimer(0)
+    local t1 = model.getTimer(1)
+    local t2 = model.getTimer(2)
+
+    -- mode == 0 means 'off'
+    if t0 ~= nil and t0.mode > 0 then
+      local t0H = math.floor(t0.value/3600)
+      local t0M = math.floor(t0.value/60) - t0H*60
+      local t0S = t0.value - t0H*3600 - t0M*60
+      local t0Str = string.format("%s %02d:%02d", t0.name, t0M, t0S)
+      if t0H > 0 then local t0Str = string.format("%s %02d:%02d:%02d", t0.name, t0H, t0M, t0S) end
+      lcd.drawText(xRight, timerY, t0Str, textStyle)
+
+      -- shift down y by one line
+      timerY = timerY + lineHeight
+    end
+
+    if t1 ~= nil and t1.mode > 0 then
+      local t1H = math.floor(t1.value/3600)
+      local t1M = math.floor(t1.value/60) - t1H*60
+      local t1S = t1.value - t1H*3600 - t1M*60
+      local t1Str = string.format("%s %02d:%02d", t1.name, t1M, t1S)
+      if t1H > 0 then local t1Str = string.format("%s %02d:%02d:%02d", t1.name, t1H, t1M, t1S) end
+      lcd.drawText(xRight, timerY, t1Str, textStyle)
+
+      -- shift down y by one line
+      timerY = timerY + lineHeight
+    end
+
+    if t2 ~= nil and t2.mode > 0 then
+      local t2H = math.floor(t2.value/3600)
+      local t2M = math.floor(t2.value/60) - t2H*60
+      local t2S = t2.value - t2H*3600 - t2M*60
+      local t2Str = string.format("%s %02d:%02d", t2.name, t2M, t2S)
+      if t2H > 0 then local t2Str = string.format("%s %02d:%02d:%02d", t2.name, t2H, t2M, t2S) end
+      lcd.drawText(xRight, timerY, t2Str, textStyle)
+
+      -- shift down y by one line
+      timerY = timerY + lineHeight
+    end
+  end
 end
 
 -- Return widget definition
 return {
-    name = "ClockWidget",
-    create = create,
-    update = update,
-    refresh = refresh,
-    options = {
-        {"Format24H", BOOL, 1}, -- 1 = 24-hour, 0 = 12-hour
-    },
+  name = "ClockWidget",
+  create = create,
+  update = update,
+  refresh = refresh,
+  options = {
+    {"Format24H", BOOL, 1}, -- 1 = 24-hour, 0 = 12-hour
+
+    -- show ISO 8601 Timestamp (%Y-%m-%d %H:%M)
+    -- instead of two lines with date and time
+    { "iso8601", BOOL, 0 },
+
+    -- show timers below timestamp
+    -- only shows ones with mode other than 'off'
+    { "timers", BOOL, 0 },
+  },
 }

--- a/widgets/ClockWidget/main.lua
+++ b/widgets/ClockWidget/main.lua
@@ -6,7 +6,6 @@ local months = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
 "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"}
 local iconPathFmt = "/WIDGETS/ClockWidget/BMP/connection-%s.png"
 
-
 -- Function to format time string
 local function getFormattedTime(datetime, is24Hour)
   local hour = datetime.hour
@@ -27,6 +26,21 @@ local function getFormattedTime(datetime, is24Hour)
   end
 
   return string.format("%02d:%02d%s", hour, datetime.min, is24Hour and "" or amPm)
+end
+
+-- get timers and draw them unless mode == 'off'
+local function drawTimer(i, x, y, style)
+  local t = model.getTimer(i)
+  if t ~= nil and t.mode > 0 then
+    local h = math.floor(t.value/3600)
+    local m = math.floor(t.value/60) - h*60
+    local s = t.value - h*3600 - m*60
+    local str = string.format("%s %02d:%02d", t.name, m, s)
+    if h > 0 then str = string.format("%s %02d:%02d:%02d", t.name, h, m, s) end
+    lcd.drawText(x, y, str, style)
+    return true
+  end
+  return false
 end
 
 -- Widget creation: preload bitmaps
@@ -101,46 +115,11 @@ local function refresh(widget, event, touchState)
     local timerY = yStart + lineHeight
     if widget.cfg.iso8601 == 0 then timerY = timerY + lineHeight end
 
-    -- get timers
-    local t0 = model.getTimer(0)
-    local t1 = model.getTimer(1)
-    local t2 = model.getTimer(2)
-
-    -- mode == 0 means 'off'
-    if t0 ~= nil and t0.mode > 0 then
-      local t0H = math.floor(t0.value/3600)
-      local t0M = math.floor(t0.value/60) - t0H*60
-      local t0S = t0.value - t0H*3600 - t0M*60
-      local t0Str = string.format("%s %02d:%02d", t0.name, t0M, t0S)
-      if t0H > 0 then local t0Str = string.format("%s %02d:%02d:%02d", t0.name, t0H, t0M, t0S) end
-      lcd.drawText(xRight, timerY, t0Str, textStyle)
-
-      -- shift down y by one line
-      timerY = timerY + lineHeight
-    end
-
-    if t1 ~= nil and t1.mode > 0 then
-      local t1H = math.floor(t1.value/3600)
-      local t1M = math.floor(t1.value/60) - t1H*60
-      local t1S = t1.value - t1H*3600 - t1M*60
-      local t1Str = string.format("%s %02d:%02d", t1.name, t1M, t1S)
-      if t1H > 0 then local t1Str = string.format("%s %02d:%02d:%02d", t1.name, t1H, t1M, t1S) end
-      lcd.drawText(xRight, timerY, t1Str, textStyle)
-
-      -- shift down y by one line
-      timerY = timerY + lineHeight
-    end
-
-    if t2 ~= nil and t2.mode > 0 then
-      local t2H = math.floor(t2.value/3600)
-      local t2M = math.floor(t2.value/60) - t2H*60
-      local t2S = t2.value - t2H*3600 - t2M*60
-      local t2Str = string.format("%s %02d:%02d", t2.name, t2M, t2S)
-      if t2H > 0 then local t2Str = string.format("%s %02d:%02d:%02d", t2.name, t2H, t2M, t2S) end
-      lcd.drawText(xRight, timerY, t2Str, textStyle)
-
-      -- shift down y by one line
-      timerY = timerY + lineHeight
+    -- draw up to three timers (0,1,2)
+    for i=0,2 do
+      if drawTimer(i,xRight,timerY,textStyle)
+        timerY = timerY + lineHeight
+      end
     end
   end
 end

--- a/widgets/GPSWidget/main.lua
+++ b/widgets/GPSWidget/main.lua
@@ -2,7 +2,6 @@
 -- Displays satellite count, latitude, and longitude with small text aligned to the right
 -- Includes color-coded satellite count and satellite icon
 
-
 local textStyle = RIGHT + WHITE + SHADOWED
 local midLineHeight = 33
 local lineHeight = 18
@@ -10,116 +9,188 @@ local lineHeight = 18
 
 -- Function to create the widget
 local function create(zone, options)
-    return {
-        zone = zone,
-        options = options,
-		update = true,
-		gpsSATS = 0,
-		gpsLAT = 0,
-		gpsLON = 0,
-		isGPSValid = true,
-    }
+  return {
+    zone = zone,
+    options = options,
+    update = true,
+    gpsSATS = 0,
+    gpsLAT = 0,
+    gpsLON = 0,
+    isGPSValid = true,
+  }
 end
 
 local function update(widget, newOptions)
-    widget.options = newOptions
+  widget.options = newOptions
 end
 
 -- Helper function to convert decimal degrees to degrees, minutes, and seconds
 local function toDMS(value)
-    local degrees = math.floor(value)
-    local minutes = math.floor((value - degrees) * 60)
-    local seconds = ((value - degrees) * 60 - minutes) * 60
-    return degrees, minutes, seconds
+  local degrees = math.floor(value)
+  local minutes = math.floor((value - degrees) * 60)
+  local seconds = ((value - degrees) * 60 - minutes) * 60
+  return degrees, minutes, seconds
 end
 
+-- helper functions for MGRS
+local function pad(val)
+    val = tostring(val)
+    while #val < 5 do
+        val = "0" .. val
+    end
+    return val
+end
+
+function latlon_to_mgrs(lat, lon)
+    if lat < -80 then return 'Too far South' end
+    if lat > 84 then return 'Too far North' end
+
+    local c = math.floor((lon + 180) / 6) + 1
+    local e = c * 6 - 183
+    local k = math.rad(lat)
+    local l = math.rad(lon)
+    local m = math.rad(e)
+    local n = math.cos(k)
+    local o = 0.006739496819936062 * (n^2)
+    local p = 40680631590769 / (6356752.314 * math.sqrt(1 + o))
+    local q = math.tan(k)
+    local r = q * q
+    local t = l - m
+    local u = 1.0 - r + o
+    local v = 5.0 - r + 9 * o + 4.0 * (o^2)
+    local w = 5.0 - 18.0 * r + r * r + 14.0 * o - 58.0 * r * o
+    local x = 61.0 - 58.0 * r + r * r + 270.0 * o - 330.0 * r * o
+    local y = 61.0 - 479.0 * r + 179.0 * r * r - r * r * r
+    local z = 1385.0 - 3111.0 * r + 543.0 * r * r - r * r * r
+
+    local aa = p * n * t +
+        (p / 6.0 * n^3 * u * t^3) +
+        (p / 120.0 * n^5 * w * t^5) +
+        (p / 5040.0 * n^7 * y * t^7)
+    local ab = 6367449.14570093 * (k - (0.00251882794504 * math.sin(2 * k)) +
+        (0.00000264354112 * math.sin(4 * k)) -
+        (0.00000000345262 * math.sin(6 * k)) +
+        (0.000000000004892 * math.sin(8 * k))) +
+        (q / 2.0 * p * n^2 * t^2) +
+        (q / 24.0 * p * n^4 * v * t^4) +
+        (q / 720.0 * p * n^6 * x * t^6) +
+        (q / 40320.0 * p * n^8 * z * t^8)
+
+    aa = aa * 0.9996 + 500000.0
+    ab = ab * 0.9996
+    if ab < 0.0 then ab = ab + 10000000.0 end
+
+    local latBands = "CDEFGHJKLMNPQRSTUVWXX"
+    local ad = latBands:sub(math.floor(lat / 8 + 10) + 1, math.floor(lat / 8 + 10) + 1)
+    local ae = math.floor(aa / 100000)
+    local digraph1Array = {"ABCDEFGH", "JKLMNPQR", "STUVWXYZ"}
+    local af = digraph1Array[(c - 1) % 3 + 1]:sub(ae, ae)
+    local ag = math.floor(ab / 100000) % 20
+    local digraph2Array = {"ABCDEFGHJKLMNPQRSTUV", "FGHJKLMNPQRSTUVABCDE"}
+    local ah = digraph2Array[(c - 1) % 2 + 1]:sub(ag + 1, ag + 1)
+
+    aa = math.floor(aa % 100000)
+    ab = math.floor(ab % 100000)
+
+    return string.format("%02d%s %s%s %s", c, ad, af, ah, pad(aa)), string.format("MGRS  %s", pad(ab))
+end
 
 -- Function to draw the satellite icon based on the satellite count
 local function getIconColor(gpsSATS)   
-    local iconColor
-    if gpsSATS <= 5 then
-        color = RED
-        iconColor = "red"
-    elseif gpsSATS <= 7 then
-        color = YELLOW
-        iconColor = "yellow"
-    else
-        color = GREEN
-        iconColor = "green"
-    end
+  local iconColor
+  if gpsSATS <= 5 then
+    color = RED
+    iconColor = "red"
+  elseif gpsSATS <= 7 then
+    color = YELLOW
+    iconColor = "yellow"
+  else
+    color = GREEN
+    iconColor = "green"
+  end
 
-    return iconColor
+  return iconColor
 end
 
 -- Function to format latitude and longitude
 local function formatLatLon(lat, lon)
-    local latDeg, latMin, latSec = toDMS(math.abs(lat))
-    local lonDeg, lonMin, lonSec = toDMS(math.abs(lon))
-    local latDir = lat >= 0 and "N" or "S"
-    local lonDir = lon >= 0 and "E" or "W"
-    return string.format("%d°%d'%d\"%s", latDeg, latMin, latSec, latDir),
-           string.format("%d°%d'%d\"%s", lonDeg, lonMin, lonSec, lonDir)
+  local latDeg, latMin, latSec = toDMS(math.abs(lat))
+  local lonDeg, lonMin, lonSec = toDMS(math.abs(lon))
+  local latDir = lat >= 0 and "N" or "S"
+  local lonDir = lon >= 0 and "E" or "W"
+  return string.format("%d°%d'%d\"%s", latDeg, latMin, latSec, latDir),
+  string.format("%d°%d'%d\"%s", lonDeg, lonMin, lonSec, lonDir)
 end
 
 local function drawGpsTelemetry(widget) 
 
-    -- Define positions
-    local xRight = widget.zone.x + widget.zone.w - 10
-    local yStart = widget.zone.y + 5
-    
-    -- Get telemetry data
-    widget.gpsSATS = tonumber(getValue("Sats")) or 0
-    widget.gpsLatLon = getValue("GPS")
+  -- Define positions
+  local xRight = widget.zone.x + widget.zone.w - 10
+  local yStart = widget.zone.y + 5
+
+  -- Get telemetry data
+  widget.gpsSATS = tonumber(getValue("Sats")) or 0
+  widget.gpsLatLon = getValue("GPS")
 
 
-    if (type(widget.gpsLatLon) == "table") then 			
-        widget.gpsLAT = widget.gpsLatLon.lat or 0
-        widget.gpsLON = widget.gpsLatLon.lon or 0	
-        widget.isGPSValid = true	
-        widget.update = true
-    else
-        widget.isGPSValid = false
-        widget.update = false
+  if (type(widget.gpsLatLon) == "table") then       
+    widget.gpsLAT = widget.gpsLatLon.lat or 0
+    widget.gpsLON = widget.gpsLatLon.lon or 0 
+    widget.isGPSValid = true  
+    widget.update = true
+  else
+    widget.isGPSValid = false
+    widget.update = false
+  end
+
+  -- Format latitude and longitude
+  local latStr, lonStr = formatLatLon(widget.gpsLAT, widget.gpsLON)
+
+  if widget.isGPSValid then
+    local iconPath = "/WIDGETS/GPSWidget/BMP/satellite-%s.png"
+    local icon = Bitmap.open(string.format(iconPath, getIconColor(widget.gpsSATS)))
+    lcd.drawBitmap(icon, xRight-22, yStart)
+    lcd.drawText(xRight - 35, yStart + 2, string.format("Sats: %d", widget.gpsSATS), textStyle  + MIDSIZE)
+
+    if widget.options.MGRS == 1 then
+      local a,b = latlon_to_mgrs(widget.gpsLAT, widget.gpsLON)
+      lcd.drawText(xRight, yStart + midLineHeight + 2, a, textStyle + MIDSIZE)
+      lcd.drawText(xRight, yStart + midLineHeight + lineHeight + 4, b, textStyle + MIDSIZE)
+    elseif widget.options.Coordinates == 1 then
+      lcd.drawText(xRight, yStart + midLineHeight, "Lat: " .. latStr, textStyle)
+      lcd.drawText(xRight, yStart + midLineHeight + lineHeight, "Lon: " .. lonStr, textStyle)    
     end
 
-    -- Format latitude and longitude
-    local latStr, lonStr = formatLatLon(widget.gpsLAT, widget.gpsLON)
-
-    if widget.isGPSValid then
-        local iconPath = "/WIDGETS/GPSWidget/BMP/satellite-%s.png"
-        local icon = Bitmap.open(string.format(iconPath, getIconColor(widget.gpsSATS)))
-        lcd.drawBitmap(icon, xRight-22, yStart)
-        lcd.drawText(xRight - 35, yStart + 2, string.format("Sats: %d", widget.gpsSATS), textStyle  + MIDSIZE)
-
-        if widget.options.Coordinates == 1 then
-            lcd.drawText(xRight, yStart + midLineHeight, "Lat: " .. latStr, textStyle)
-            lcd.drawText(xRight, yStart + midLineHeight + lineHeight, "Lon: " .. lonStr, textStyle)    
-        end
+  else
+    if widget.gpsLAT == 0 and widget.gpsLON == 0 then
+      lcd.drawText(xRight - 35, yStart + 2, "No GPS", textStyle + MIDSIZE)
     else
-        if widget.gpsLAT == 0 and widget.gpsLON == 0 then
-            lcd.drawText(xRight - 35, yStart + 2, "No GPS", textStyle + MIDSIZE)
-        else
-            lcd.drawText(xRight + 10, yStart + 2, "Last location: ", textStyle + MIDSIZE)
-            lcd.drawText(xRight, yStart + midLineHeight, "Lat: " .. latStr, textStyle)
-            lcd.drawText(xRight, yStart + midLineHeight + lineHeight, "Lon: " .. lonStr, textStyle)
-        end
+      lcd.drawText(xRight + 10, yStart + 2, "Last location: ", textStyle + MIDSIZE)
+
+      if widget.options.MGRS == 1 then
+        lcd.drawText(xRight, yStart + midLineHeight + 2, a, textStyle + MIDSIZE)
+        lcd.drawText(xRight, yStart + midLineHeight + lineHeight + 4, b, textStyle + MIDSIZE)
+      else
+        lcd.drawText(xRight, yStart + midLineHeight, "Lat: " .. latStr, textStyle)
+        lcd.drawText(xRight, yStart + midLineHeight + lineHeight, "Lon: " .. lonStr, textStyle)
+      end
     end
+  end
 
 end
 
 local function refresh(widget, event, touchState)
-
-    drawGpsTelemetry(widget)
-
+  drawGpsTelemetry(widget)
 end
 
 return {
-    name = "GPSWidget",
-    options = {},
-    create = create,
-    update = update,
-    refresh = refresh,
-    options = {
-        {"Coordinates", BOOL, 1},
-      },
+  name = "GPSWidget",
+  options = {},
+  create = create,
+  update = update,
+  refresh = refresh,
+  options = {
+    {"Coordinates", BOOL, 1},
+    {"MGRS", BOOL, 0},
+  },
 }

--- a/widgets/SimModel/README.md
+++ b/widgets/SimModel/README.md
@@ -1,0 +1,17 @@
+# SimModel Widget
+... now with options to change the visual representation.
+The defaults are set to keep everything as it was before.
+
+## Options
+
+**iso8601**
+Show the Date and Time in a single line in `%Y-%m-%d %H:%M` format.
+
+**timers**
+Show the three timers below Date/Time.
+Only shows timers with a mode other than 'off'.
+
+**sim_designator**
+Remove the `Simulator` text from below the model name.
+That makes space for placing a logo on the background/theme.
+default: 1/on = show `Simulator` - set to 0/off to hide it.

--- a/widgets/SimModel/main.lua
+++ b/widgets/SimModel/main.lua
@@ -52,6 +52,21 @@ local function create(zone, options)
   return widget
 end
 
+-- get timers and draw them unless mode == 'off'
+local function drawTimer(i, x, y, style)
+  local t = model.getTimer(i)
+  if t ~= nil and t.mode > 0 then
+    local h = math.floor(t.value/3600)
+    local m = math.floor(t.value/60) - h*60
+    local s = t.value - h*3600 - m*60
+    local str = string.format("%s %02d:%02d", t.name, m, s)
+    if h > 0 then str = string.format("%s %02d:%02d:%02d", t.name, h, m, s) end
+    lcd.drawText(x, y, str, style)
+    return true
+  end
+  return false
+end
+
 local function update(widget, options)
   -- Runs if options are changed from the Widget Settings menu
   widget.cfg = options
@@ -139,10 +154,6 @@ local function drawDateAndTime(widget)
 end
 
 local function drawTimers(widget)
-  local t0 = model.getTimer(0)
-  local t1 = model.getTimer(1)
-  local t2 = model.getTimer(2)
-
   -- Define positions
   local xRight = widget.zone.x + widget.zone.w - 10
   local y = widget.zone.y + 5 + lineHeight
@@ -150,41 +161,11 @@ local function drawTimers(widget)
   -- shift down one unless ISO8601 (two lines vs one)
   if widget.cfg.iso8601 == 0 then y = y + lineHeight end
 
-  -- mode == 0 means 'off'
-  if t0 ~= nil and t0.mode > 0 then
-    local t0H = math.floor(t0.value/3600)
-    local t0M = math.floor(t0.value/60) - t0H*60
-    local t0S = t0.value - t0H*3600 - t0M*60
-    local t0Str = string.format("%s %02d:%02d", t0.name, t0M, t0S)
-    if t0H > 0 then local t0Str = string.format("%s %02d:%02d:%02d", t0.name, t0H, t0M, t0S) end
-    lcd.drawText(xRight, y, t0Str, textStyleRight)
-
-    -- shift down y by one line
-    y = y + lineHeight
-  end
-
-  if t1 ~= nil and t1.mode > 0 then
-    local t1H = math.floor(t1.value/3600)
-    local t1M = math.floor(t1.value/60) - t1H*60
-    local t1S = t1.value - t1H*3600 - t1M*60
-    local t1Str = string.format("%s %02d:%02d", t1.name, t1M, t1S)
-    if t1H > 0 then local t1Str = string.format("%s %02d:%02d:%02d", t1.name, t1H, t1M, t1S) end
-    lcd.drawText(xRight, y, t1Str, textStyleRight)
-
-    -- shift down y by one line
-    y = y + lineHeight
-  end
-
-  if t2 ~= nil and t2.mode > 0 then
-    local t2H = math.floor(t2.value/3600)
-    local t2M = math.floor(t2.value/60) - t2H*60
-    local t2S = t2.value - t2H*3600 - t2M*60
-    local t2Str = string.format("%s %02d:%02d", t2.name, t2M, t2S)
-    if t2H > 0 then local t2Str = string.format("%s %02d:%02d:%02d", t2.name, t2H, t2M, t2S) end
-    lcd.drawText(xRight, y, t2Str, textStyleRight)
-
-    -- shift down y by one line
-    y = y + lineHeight
+  -- draw up to three timers (0,1,2)
+  for i=0,2 do
+    if drawTimer(i,xRight,y,textStyleRight)
+      y = y + lineHeight
+    end
   end
 end
 

--- a/widgets/SimStick/README.md
+++ b/widgets/SimStick/README.md
@@ -1,0 +1,12 @@
+# SimStick Widget
+... now with options to change the visual representation.
+The defaults are set to keep everything as it was before.
+
+## Options
+
+**values_down**
+Move row with axis vlaues below crosshairs.
+
+**sticks_out**
+Move crosshairs to the side.
+That makes space for placing a logo on the background/theme.

--- a/widgets/SimStick/main.lua
+++ b/widgets/SimStick/main.lua
@@ -5,6 +5,14 @@ local lineHeight = 18
 local xLeft = 10
 local yStart = 5
 
+local options = {
+  -- move values down
+  { "values_down", BOOL, 0 },
+
+  -- move sticks out
+  { "sticks_out", BOOL, 0 },
+}
+
 -- Stick field IDs (initialized once)
 local fieldInfo = {
     rud = getFieldInfo('rud').id,
@@ -69,6 +77,16 @@ local function drawSticks(widget)
     local centerX = widget.zone.x + widget.zone.w / 2
     local centerY = widget.zone.y + widget.zone.h / 2 + 10
 
+    local leftX = centerX - 80
+    local rightX = centerX + 60
+
+    -- move sticks slighly up
+    if widget.cfg.sticks_out == 1 then
+      centerY = centerY - 15
+      leftX = leftX - 100
+      rightX = rightX + 120
+    end
+
     local function drawAxesAndStick(posX, posY, idX, idY)
         for i = -1, 1 do
             lcd.drawLine(posX - axisLength, posY + i, posX + axisLength, posY + i, SOLID, WHITE)
@@ -82,20 +100,25 @@ local function drawSticks(widget)
     end
 
     -- T-R chart (left) and A-E chart (right)
-    drawAxesAndStick(centerX - 80, centerY, sticks[2].idX, sticks[2].idY)  -- R = X, T = Y
-    drawAxesAndStick(centerX + 60, centerY, sticks[1].idX, sticks[1].idY)  -- A = X, E = Y
+    drawAxesAndStick(leftX, centerY, sticks[2].idX, sticks[2].idY)  -- R = X, T = Y
+    drawAxesAndStick(rightX, centerY, sticks[1].idX, sticks[1].idY)  -- A = X, E = Y
 end
 
 -- Main refresh function
 local function refresh(widget, event, touchState)
     drawSticks(widget)
-    drawStickValues(xLeft + 30, yStart)
+
+    if widget.cfg.values_down == 0 then
+      drawStickValues(xLeft + 30, yStart)
+    else
+      drawStickValues(xLeft + 30, 130)
+    end
 end
 
 -- Widget registration
 return {
     name = "SimStick",
-    options = {},
+    options = options,
     create = create,
     update = update,
     refresh = refresh,


### PR DESCRIPTION
Changes:
- change Date/Time to single line ISO 8601-ish view (both in SimModel and ClockWidget)
- add timers below Date/Time (both in SimModel and ModelWidget)
- Remove `Simulator` designator (in SimModel)
- Move Axis Values below Crosshairs (in SimSticks)
- Move Crosshairs out (in SimSticks)
- display Lat/Lon in MGRS (in GPSWidget)

basically, cosmetic changes that allow you to place an Image/Logo in the middle of your Background and still see it ;)
I also prefer entering MGRS on my Garmin Watch to navigate to the last known position.

![sim](https://github.com/user-attachments/assets/42308957-2d4c-4df0-a8c6-43ee76f8b829)
